### PR TITLE
Allow decimals to be entered as price

### DIFF
--- a/src/main/java/View/GroupSummaryView.java
+++ b/src/main/java/View/GroupSummaryView.java
@@ -229,7 +229,7 @@ public class GroupSummaryView extends JPanel implements ActionListener {
                 AddPurchaseView addPurchaseView = new AddPurchaseView(
                         this.groupUserNames);
 
-                if ((addPurchaseView.getItemPrice().matches("[0-9]+")) && (addPurchaseView.getSelectedMembers().size() > 0)) {
+                if ((addPurchaseView.getItemPrice().matches("\\d*\\.?\\d*")) && (addPurchaseView.getSelectedMembers().size() > 0)) {
                     float item_price = Float.parseFloat(addPurchaseView.getItemPrice());
                     UpdatedLists updatedList = controllerAddPurchase.controlAddPurchaseUseCase(itemID,
                             addPurchaseView.getSelectedMembers(), this.username, item_price, this.groupID);


### PR DESCRIPTION
Previously, if you entered a decimal as the cost of an item, it would return ""Error with inputs!" I felt very compelled to fix this issue because most items that are purchased IRL are decimal values. For example, eggs $3.59. With this new pull request, we can now enter that value.

The error lay in the GroupSummaryView. The regex that was used to ensure a numeric value was inputted did not allow for a decimal. I am please to fix this issue.

Thank you Flipwise team in advance for your prompt response to this issue.

Closes #85 